### PR TITLE
UE-NIB reader implementation for the first APIs

### DIFF
--- a/example/event_reader/event_reader.go
+++ b/example/event_reader/event_reader.go
@@ -18,7 +18,13 @@ import (
 )
 
 type ueEventInfo struct {
-	ueID uenib.UeID
+	ueID             uenib.UeID
+	s1ULTunEndpoints []gtpTunnel
+}
+
+type gtpTunnel struct {
+	address string
+	teid    string
 }
 
 type logEvent struct {
@@ -36,7 +42,9 @@ var logChannel chan logEvent
 
 func init() {
 	myReader = uenibreader.NewReader()
+	//A channel is created per GNb 'someGNb'
 	someGNb = "somegnb:310-410-b5c67788"
+	//someGNb = "someGNbID0"
 	ueDcEstablishEventChannel = make(chan ueEventInfo)
 	ueDcReleaseEventChannel = make(chan ueEventInfo)
 	logChannel = make(chan logEvent)
@@ -64,15 +72,80 @@ func queryExecutor(wg *sync.WaitGroup) {
 }
 
 func doSomeDbQueries(info *ueEventInfo, evType string) {
+	doSomeUeDbQueries(&info.ueID, evType)
+}
+
+func doSomeUeDbQueries(ueID *uenib.UeID, evType string) {
 	log := logEvent{function: evType}
-	cell, err := myReader.GetPsCell(&info.ueID)
+	eNbUeX2ApID, err := myReader.GetMeNbUEX2APID(ueID)
 	if err != nil {
-		panic(fmt.Sprintf("GetPsCell failed, error: %s\n", err.Error()))
+		panic(fmt.Sprintf("GetMeNbUEX2APID(%s) failed, error: %s\n", ueID.String(), err.Error()))
 	}
-	log.lines = append(log.lines, fmt.Sprintf("GetPsCell(%s)", info.ueID.String()))
-	log.lines = append(log.lines, fmt.Sprintf("   PsCell:%v", cell))
+	gNbUeX2ApID, err := myReader.GetSgNbUEX2APID(ueID)
+	if err != nil {
+		panic(fmt.Sprintf("GetSgNbUEX2APID(%s) failed, error: %s\n", ueID.String(), err.Error()))
+	}
+	ueState, _ := myReader.GetState(ueID)
+	if err != nil {
+		panic(fmt.Sprintf("GetState(%s) failed, error: %s\n", ueID.String(), err.Error()))
+	}
+	cell, err := myReader.GetPsCell(ueID)
+	if err != nil {
+		panic(fmt.Sprintf("GetPsCell(%s) failed, error: %s\n", ueID.String(), err.Error()))
+	}
+	erabIDs, err := myReader.GetBearerIDs(ueID)
+	if err != nil {
+		panic(fmt.Sprintf("GetBearerIDs(%s) failed, error: %s\n", ueID.String(), err.Error()))
+	}
+	erabs, _ := myReader.GetBearers(ueID)
+	if err != nil {
+		panic(fmt.Sprintf("GetBearers(%s) failed, error: %s\n", ueID.String(), err.Error()))
+	}
+
+	log.lines = append(log.lines, fmt.Sprintf("GetMeNbUEX2APID(%s) = %d", ueID.String(), eNbUeX2ApID))
+	log.lines = append(log.lines, fmt.Sprintf("GetSgNbUEX2APID(%s) = %d", ueID.String(), gNbUeX2ApID))
+	log.lines = append(log.lines, fmt.Sprintf("GetState(%s) = %v", ueID.String(), ueState))
+	log.lines = append(log.lines, fmt.Sprintf("GetPsCell(%s) = %v", ueID.String(), cell))
+	log.lines = append(log.lines, fmt.Sprintf("GetBearerIDs(%s) = %v", ueID.String(), erabIDs))
+	log.lines = append(log.lines, fmt.Sprintf("GetBearers(%s) = %v", ueID.String(), erabs))
 	logChannel <- log
-	//@todo Add here more examples of other UE-NIB read queries.
+
+	for _, erabID := range erabIDs {
+		doSomeUeErabDbQueries(ueID, erabID, evType)
+	}
+}
+
+func doSomeUeErabDbQueries(ueID *uenib.UeID, erabID uenib.ErabID, evType string) {
+	log := logEvent{function: evType}
+
+	te, err := myReader.GetErabS1ULGtpTE(ueID, erabID)
+	if err != nil {
+		panic(fmt.Sprintf("GetErabS1ULGtpTE(%s, %d) failed, error: %s\n", ueID.String(), erabID, err.Error()))
+	}
+	teAddr, err := myReader.GetErabS1ULGtpTEAddr(ueID, erabID)
+	if err != nil {
+		panic(fmt.Sprintf("GetErabS1ULGtpTEAddr(%s, %d) failed, error: %s\n", ueID.String(), erabID, err.Error()))
+	}
+	teTeid, err := myReader.GetErabS1ULGtpTETeid(ueID, erabID)
+	if err != nil {
+		panic(fmt.Sprintf("GetErabS1ULGtpTETeid(%s, %d) failed, error: %s\n", ueID.String(), erabID, err.Error()))
+	}
+	arpPL, err := myReader.GetErabQosArpPL(ueID, erabID)
+	if err != nil {
+		panic(fmt.Sprintf("GetErabQosArpPL(%s, %d) failed, error: %s\n", ueID.String(), erabID, err.Error()))
+	}
+	qci, err := myReader.GetErabQosQci(ueID, erabID)
+	if err != nil {
+		panic(fmt.Sprintf("GetErabQosQci(%s, %d) failed, error: %s\n", ueID.String(), erabID, err.Error()))
+	}
+
+	log.lines = append(log.lines, fmt.Sprintf("GetErabS1ULGtpTE(%s, %d) = %v", ueID.String(), erabID, te))
+	log.lines = append(log.lines, fmt.Sprintf("GetErabS1ULGtpTEAddr(%s, %d) = %v", ueID.String(), erabID, teAddr))
+	log.lines = append(log.lines, fmt.Sprintf("GetErabS1ULGtpTETeid(%s, %d) = %v", ueID.String(), erabID, teTeid))
+	log.lines = append(log.lines, fmt.Sprintf("GetErabQosArpPL(%s, %d) = %d", ueID.String(), erabID, arpPL))
+	log.lines = append(log.lines, fmt.Sprintf("GetErabQosQos(%s, %d) = %d", ueID.String(), erabID, qci))
+
+	logChannel <- log
 }
 
 func logger(wg *sync.WaitGroup, channel chan logEvent) {
@@ -95,14 +168,45 @@ func eventMatches(event string, pattern string) bool {
 
 func parseEventInfo(event string) ueEventInfo {
 	var retInfo ueEventInfo
-	ueFields := strings.Split(event, "#")
-	if cnt := len(ueFields); cnt != 3 {
-		panic(fmt.Sprintf("Too many (%d) UE fields in event string: %s\n", cnt, event))
+	ueAndS1UPTEP := strings.Split(event, "_")
+	if cnt := len(ueAndS1UPTEP); cnt != 2 {
+		panic(fmt.Sprintf("Wrong number (%d) of UE/S1UL tunnel endpoints in event string: %s\n", cnt, event))
 	}
-	retInfo.ueID.GNb = ueFields[0]
-	retInfo.ueID.GNbUeX2ApID = ueFields[1]
-	retInfo.ueID.ENbUeX2ApID = ueFields[2]
+	ue := ueAndS1UPTEP[0]
+	s1UPTEP := ueAndS1UPTEP[1]
+
+	retInfo.ueID = parseEventInfoUeId(ue)
+	retInfo.s1ULTunEndpoints = parseEventInfoS1ULTEPs(s1UPTEP)
 	return retInfo
+}
+
+func parseEventInfoUeId(ueStr string) uenib.UeID {
+	var retUeID uenib.UeID
+	ueFields := strings.Split(ueStr, "#")
+	if cnt := len(ueFields); cnt != 3 {
+		panic(fmt.Sprintf("Wrong number (%d) of UE fields in event string: %s\n", cnt, ueStr))
+	}
+	retUeID.GNb = ueFields[0]
+	retUeID.GNbUeX2ApID = ueFields[1]
+	retUeID.ENbUeX2ApID = ueFields[2]
+	return retUeID
+}
+
+func parseEventInfoS1ULTEPs(tepsStr string) []gtpTunnel {
+	var retTEPs []gtpTunnel
+	tepFields := strings.Split(tepsStr, "#")
+	if len(tepFields)%2 != 0 {
+		panic(fmt.Sprintf("S1UL tunnel endpoints address and teid count (%d) not even. String: %s\n",
+			len(tepFields), tepFields))
+	}
+	for i := 0; i < len(tepFields); i = i + 2 {
+		t := gtpTunnel{
+			address: tepFields[i],
+			teid:    tepFields[i+1],
+		}
+		retTEPs = append(retTEPs, t)
+	}
+	return retTEPs
 }
 
 func subscribeEvents() {
@@ -111,11 +215,11 @@ func subscribeEvents() {
 			for _, ev := range evs {
 				switch eventCategory {
 				case uenibreader.DualConnectivity:
-					if eventMatches(ev, ".*_ESTABLISH") {
-						ueDcEstablishEventChannel <- parseEventInfo(strings.TrimSuffix(ev, "_ESTABLISH"))
+					if eventMatches(ev, ".*_S1UL_TUNNEL_ESTABLISH") {
+						ueDcEstablishEventChannel <- parseEventInfo(strings.TrimSuffix(ev, "_S1UL_TUNNEL_ESTABLISH"))
 					}
-					if eventMatches(ev, ".*_RELEASE") {
-						ueDcReleaseEventChannel <- parseEventInfo(strings.TrimSuffix(ev, "_RELEASE"))
+					if eventMatches(ev, ".*_S1UL_TUNNEL_RELEASE") {
+						ueDcReleaseEventChannel <- parseEventInfo(strings.TrimSuffix(ev, "_S1UL_TUNNEL_RELEASE"))
 					}
 				}
 			}
@@ -167,6 +271,6 @@ func main() {
 	go queryExecutor(&ueDcReaderWaitGroup)
 
 	//@todo Better closing, now just close the example after 2 seconds.
-	time.Sleep(2 * time.Second)
+	time.Sleep(20 * time.Second)
 	teardown()
 }

--- a/pkg/uenib/types.go
+++ b/pkg/uenib/types.go
@@ -5,6 +5,7 @@
    SPDX-License-Identifier: BSD-3-Clause-Clear
 */
 
+//Package uenib provides UE-NIB public data types.
 package uenib
 
 import (
@@ -28,6 +29,8 @@ type ErabID uint32
 type Bearer struct {
 	ErabID    ErabID
 	DrbID     uint32
+	ArpPL     uint32
+	Qci       uint32
 	S1ULGtpTE TunnelEndpoint
 }
 
@@ -45,8 +48,8 @@ type Cell struct {
 
 //UeState is a holder for a UE state.
 type UeState struct {
-	Event     string
-	Timestamp string
+	Event string //A string of a timestamp and UE's last X2 message what UE-NIB has detected.
+	Cause string //X2 message's Cause IE value what UE-NIB has lastly detected.
 }
 
 //Helper function to print UeID.

--- a/pkg/uenibreader/errors.go
+++ b/pkg/uenibreader/errors.go
@@ -9,50 +9,121 @@ package uenibreader
 
 import (
 	"fmt"
+	"github.com/nokia/ue-nib-library/pkg/uenib"
 )
 
 //An Error interface represents a UE-NIB error.
 type Error interface {
 	error            //Embedded built-in error interface
-	Temporary() bool //Returns true if an error is temporary
+	Temporary() bool //Returns true if an error is temporary and it is recommended to re-try failed operation
+}
+
+//A valueNotFoundFailure is UE-NIB private type for a circumstance when queried value is not found from database.
+type valueNotFoundFailure struct {
+	ueID      uenib.UeID //Identity of a user in question
+	name      string     //Parameter name
+	temporary bool       //Defines whether the error is temporary or not
 }
 
 //An validationError is UE-NIB private type to hold classification data of validation type of error.
 type validationError struct {
-	err string //Error message
+	ueID      uenib.UeID //Identity of a user in question
+	err       string     //Error message
+	temporary bool       //Defines whether the error is temporary or not
 }
 
 //An internalError is UE-NIB private type to hold classification data of internal type of error.
 type internalError struct {
-	err string //Error message
+	ueID      uenib.UeID //Identity of a user in question
+	err       string     //Error message
+	temporary bool       //Defines whether the error is temporary or not
 }
 
 //A backendError is UE-NIB private type to hold classification data of database backend error
 //type of error. Backend errors are temporal by their nature. UE-NIB API user is adviced to try
 //again failed UE-NIB API operation.
 type backendError struct {
-	err       string //Error message
-	temporary bool   //Defines whether the error is temporary or not
+	ueID      uenib.UeID //Identity of a user in question
+	err       string     //Error message
+	temporary bool       //Defines whether the error is temporary or not
+}
+
+//Error implements built-in error interface for valueNotFoundFailure type.
+func (e *valueNotFoundFailure) Error() string {
+	return fmt.Sprintf("UE-NIB %s value of DB key '%s' not found", e.ueID.String(), e.name)
+}
+
+//IsValueNotFoundFailure returns true if failure is UE-NIB valueNotFoundFailure type.
+func IsValueNotFoundFailure(e interface{}) bool {
+	if _, ok := e.(*valueNotFoundFailure); ok {
+		return true
+	}
+	return false
+}
+
+//Temporary implements Error interface for valueNotFoundFailure type.
+//Returns always true for a valueNotFoundFailure error type. Failure is temporal and hence it is
+//recommended to re-try failed UE-NIB operation.
+func (e *valueNotFoundFailure) Temporary() bool {
+	return e.temporary
 }
 
 //Error implements built-in error interface for validationError type.
 func (e *validationError) Error() string {
-	return fmt.Sprintf("UE-NIB validation error: %s", e.err)
+	return fmt.Sprintf("UE-NIB %s validation error: %s", e.ueID.String(), e.err)
+}
+
+//IsValidationError returns true if an error is UE-NIB validationError type.
+func IsValidationError(e interface{}) bool {
+	if _, ok := e.(*validationError); ok {
+		return true
+	}
+	return false
+}
+
+//Temporary implements Error interface for validationError type.
+//Returns always false for a validationError error type. Error is permanent and hence is not worth
+//to re-try failed UE-NIB operation.
+func (e *validationError) Temporary() bool {
+	return e.temporary
 }
 
 //Error implements built-in error interface for internalError type.
 func (e *internalError) Error() string {
-	return fmt.Sprintf("UE-NIB internal error: %s", e.err)
+	return fmt.Sprintf("UE-NIB %s internal error: %s", e.ueID.String(), e.err)
+}
+
+//IsInternalError returns true if an error is UE-NIB internalError type.
+func IsInternalError(e interface{}) bool {
+	if _, ok := e.(*internalError); ok {
+		return true
+	}
+	return false
+}
+
+//Temporary implements Error interface for internalError type.
+//Returns always false for an internalError error type. Error is permanent and hence is not worth
+//to re-try failed UE-NIB operation.
+func (e *internalError) Temporary() bool {
+	return e.temporary
 }
 
 //Error implements built-in error interface for backendError type.
 func (e *backendError) Error() string {
-	return fmt.Sprintf("UE-NIB database backend error: %s", e.err)
+	return fmt.Sprintf("UE-NIB %s database backend error: %s", e.ueID.String(), e.err)
+}
+
+//IsBackendError returns true if an error is UE-NIB backendError type.
+func IsBackendError(e interface{}) bool {
+	if _, ok := e.(*backendError); ok {
+		return true
+	}
+	return false
 }
 
 //Temporary implements Error interface for backendError type.
-//Returns true if backend failure was temporal and it is recommended to re-try failed UE-NIB
-//operation.
-func (f *backendError) Temporary() bool {
-	return f.temporary
+//Returns always true for a backendError error type. Error is temporal and hence it is recommended
+//to re-try failed UE-NIB operation.
+func (e *backendError) Temporary() bool {
+	return e.temporary
 }

--- a/pkg/uenibreader/event.go
+++ b/pkg/uenibreader/event.go
@@ -16,15 +16,20 @@ const (
 	//DualConnectivity events are triggered after dual connectivity related data has been updated.
 	//
 	//Following events are possible in this category:
-	//    <UE_ID>_ESTABLISH
+	//    <UE_ID>_<S1UL_TUN_ENDPOINT>_S1UL_TUNNEL_ESTABLISH
 	//        -UE ENDC established.
-	//    <UE_ID>_RELEASE
+	//    <UE_ID>_<S1UL_TUN_ENDPOINT>_S1UL_TUNNEL_RELEASE
 	//        -UE ENDC released.
 	//    GNB_ALL_UES_REMOVE
 	//        All UEs within the gNB were removed.
-	//Where <UE_ID> identifies an UE in question and it consists of three sub-fields:
+	//
+	//<UE_ID> identifies an UE in question. It consists of three sub-fields:
 	//<GNb>#<GNbUeX2ApID>#<ENbUeX2ApID>. Note that GNb is form of a RanName:
 	//<Antenna-Type>:<3 MCC digits>-<3 MNC digits>-<Node ID>.
+	//<S1UL_TUN_ENDPOINT> identifies UE bearer's S1 uplink GTP tunnel endpoint. It consists of two
+	//sub-fields:
+	//<Transport address>#<GTP TEID>. Note that multiple endpoints can be notified by a single
+	//event. <S1UL_TUN_ENDPOINT> fields are separated by hashtag '#' in a event string.
 	DualConnectivity EventCategory = iota
 )
 

--- a/pkg/uenibreader/event_test.go
+++ b/pkg/uenibreader/event_test.go
@@ -75,10 +75,10 @@ func TestSubscribeEventsFailure(t *testing.T) {
 	err := i.SubscribeEvents([]string{someGNb}, []uenibreader.EventCategory{someEventCategory},
 		func(string, uenibreader.EventCategory, []string) {})
 	assert.NotNil(t, err)
-	temporalFailure, ok := err.(uenibreader.Error)
+	uenibError, ok := err.(uenibreader.Error)
 	assert.Equal(t, true, ok)
-	assert.Equal(t, true, temporalFailure.Temporary())
-	assert.Contains(t, err.Error(), "UE-NIB database backend error")
+	assert.Equal(t, true, uenibError.Temporary())
+	assert.Contains(t, err.Error(), "database backend error: Some DB Backend Error")
 	m.AssertExpectations(t)
 }
 
@@ -104,9 +104,10 @@ func TestSubscribeEventsUnknownEventCategoryFailure(t *testing.T) {
 	unknownEventCategory := uenibreader.EventCategory(9999999999)
 	err := i.SubscribeEvents([]string{someGNb}, []uenibreader.EventCategory{unknownEventCategory}, tracker.callback)
 	tracker.verify(t, 0)
-	_, ok := err.(uenibreader.Error)
-	assert.Equal(t, false, ok)
-	assert.Contains(t, err.Error(), fmt.Sprintf("UE-NIB validation error: Unknown event category ID: %d", unknownEventCategory))
+	uenibError, ok := err.(uenibreader.Error)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, false, uenibError.Temporary())
+	assert.Contains(t, err.Error(), fmt.Sprintf("validation error: Unknown event category ID: %d", unknownEventCategory))
 	m.AssertExpectations(t)
 }
 

--- a/pkg/uenibreader/internal/dbkey.go
+++ b/pkg/uenibreader/internal/dbkey.go
@@ -1,0 +1,71 @@
+/*
+   Copyright (c) 2020 Nokia.
+
+   Licensed under the BSD 3-Clause Clear License.
+   SPDX-License-Identifier: BSD-3-Clause-Clear
+*/
+
+package internal
+
+import (
+	"fmt"
+	"github.com/nokia/ue-nib-library/pkg/uenib"
+)
+
+func DbKeyUeMapGNbToENbUeX2ApID(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.GNbUeX2ApID + ",UEMAP_ENBUEX2APID"
+}
+
+func DbKeyUeMapENbToGNbUeX2ApID(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UEMAP_GNBUEX2APID"
+}
+
+func DbKeyUeStateEvent(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_STATE_EVENT"
+}
+
+func DbKeyUeStateCause(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_STATE_CAUSE"
+}
+
+func DbKeyPsCellPci(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_PSCELL_PCI"
+}
+
+func DbKeyPsCellSsbFreq(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_PSCELL_FREQ"
+}
+
+func DbKeyUeErabIDs(ueID *uenib.UeID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_ERAB_IDS"
+}
+
+func DbKeyErabDrbID(ueID *uenib.UeID, erabID uenib.ErabID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_DRB_ID"
+}
+
+func DbKeyErabS1UlGtpTendpAddr(ueID *uenib.UeID, erabID uenib.ErabID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
+}
+
+func DbKeyErabS1UlGtpTendpTeid(ueID *uenib.UeID, erabID uenib.ErabID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
+}
+
+func DbKeyErabQosArpPL(ueID *uenib.UeID, erabID uenib.ErabID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_QOS_ARP_PL"
+}
+
+func DbKeyErabQosQci(ueID *uenib.UeID, erabID uenib.ErabID) string {
+	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_QOS_QCI"
+}
+
+func GetErabAllDbKeys(ueID *uenib.UeID, erabID uenib.ErabID) []string {
+	return []string{
+		DbKeyErabDrbID(ueID, erabID),
+		DbKeyErabS1UlGtpTendpAddr(ueID, erabID),
+		DbKeyErabS1UlGtpTendpTeid(ueID, erabID),
+		DbKeyErabQosArpPL(ueID, erabID),
+		DbKeyErabQosQci(ueID, erabID),
+	}
+}

--- a/pkg/uenibreader/query.go
+++ b/pkg/uenibreader/query.go
@@ -8,99 +8,408 @@
 package uenibreader
 
 import (
+	"errors"
+	"fmt"
 	"github.com/nokia/ue-nib-library/pkg/uenib"
+	"github.com/nokia/ue-nib-library/pkg/uenibreader/internal"
+	"strconv"
+	"strings"
 )
 
 //GetMeNbUEX2APID returns UE MeNbUEX2APID.
 //Parameter ueID identifies User equipment (UE).
 func (reader *Reader) GetMeNbUEX2APID(ueID *uenib.UeID) (uint32, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return uint32(0), err
+	if len(ueID.GNb) == 0 {
+		return uint32(0), toValidationError(ueID, errors.New(fmt.Sprintf("%s :: missing GNb", ueID.String())))
+	}
+
+	if len(ueID.GNbUeX2ApID) == 0 {
+		return uint32(0), toValidationError(ueID, errors.New(fmt.Sprintf("%s :: missing GNbUeX2ApID", ueID.String())))
+	}
+
+	key := internal.DbKeyUeMapGNbToENbUeX2ApID(ueID)
+
+	q, err := reader.newGetQuery(ueID, []string{key})
+	if err != nil {
+		return uint32(0), err
+	}
+
+	return q.getKeyUint32Value(ueID, key)
 }
 
 //GetSgNbUEX2APID returns UE SgNbUEX2APID.
 //Parameter ueID identifies User equipment (UE).
 func (reader *Reader) GetSgNbUEX2APID(ueID *uenib.UeID) (uint32, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return uint32(0), err
+	if len(ueID.GNb) == 0 {
+		return uint32(0), toValidationError(ueID, errors.New(fmt.Sprintf("%s :: missing GNb", ueID.String())))
+	}
+
+	if len(ueID.ENbUeX2ApID) == 0 {
+		return uint32(0), toValidationError(ueID, errors.New(fmt.Sprintf("%s :: missing ENbUeX2ApID", ueID.String())))
+	}
+
+	key := internal.DbKeyUeMapENbToGNbUeX2ApID(ueID)
+
+	q, err := reader.newGetQuery(ueID, []string{key})
+	if err != nil {
+		return uint32(0), err
+	}
+
+	return q.getKeyUint32Value(ueID, key)
 }
 
 //GetPsCell returns UE radio resource information container, called as a Primary
 //Cell in secondary Node (PSCell).
 //Parameter ueID identifies User equipment (UE).
 func (reader *Reader) GetPsCell(ueID *uenib.UeID) (*uenib.Cell, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return &uenib.Cell{}, err
+	var q *query
+	var retCell uenib.Cell
+
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
+
+	pciKey := internal.DbKeyPsCellPci(id)
+	freqKey := internal.DbKeyPsCellSsbFreq(id)
+
+	if q, err = reader.newGetQuery(ueID, []string{pciKey, freqKey}); err != nil {
+		return nil, err
+	}
+
+	if retCell.Pci, err = q.getKeyUint32Value(ueID, pciKey); err != nil {
+		return nil, err
+	}
+	if retCell.SsbFreq, err = q.getKeyUint32Value(ueID, freqKey); err != nil {
+		return nil, err
+	}
+	return &retCell, err
 }
 
-//GetState returns UE's last known state in UE-NIB
+//GetState returns UE's last known state in UE-NIB and the last GTP Cause code if there has
+//been any Cause IEs set in any UE's X2 messages.
 //Parameter ueID identifies User equipment (UE).
 func (reader *Reader) GetState(ueID *uenib.UeID) (*uenib.UeState, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return &uenib.UeState{}, err
-}
+	var q *query
+	var retState uenib.UeState
 
-//GetBearers returns active bearers (E-RABs) of an UE.
-//Parameter ueID identifies User equipment (UE).
-func (reader *Reader) GetBearers(ueID *uenib.UeID) ([]uenib.Bearer, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return make([]uenib.Bearer, 0), err
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
+
+	stateEventKey := internal.DbKeyUeStateEvent(id)
+	stateCauseKey := internal.DbKeyUeStateCause(id)
+
+	if q, err = reader.newGetQuery(ueID, []string{stateEventKey, stateCauseKey}); err != nil {
+		return nil, err
+	}
+
+	if retState.Event, err = q.getKeyStringValue(ueID, stateEventKey); err != nil {
+		return nil, err
+	}
+
+	//These is no cause value in UE-NIB, if UE's all mobility procedures are done successfully.
+	//That's why catch valueNotFoundFailure error and ignore it.
+	if retState.Cause, err = q.getKeyStringValue(ueID, stateCauseKey); err != nil {
+		if IsValueNotFoundFailure(err) {
+			err = nil
+		}
+	}
+
+	return &retState, err
 }
 
 //GetBearerIDs returns existing bearer identifiers (E-RAB IDs) of an UE.
 //Parameter ueID identifies User equipment (UE).
 func (reader *Reader) GetBearerIDs(ueID *uenib.UeID) ([]uenib.ErabID, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return make([]uenib.ErabID, 0), err
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
+
+	return reader.getErabIDs(id)
+}
+
+//GetBearers returns active bearers (E-RABs) of an UE.
+//Parameter ueID identifies User equipment (UE).
+func (reader *Reader) GetBearers(ueID *uenib.UeID) ([]uenib.Bearer, error) {
+	var q *query
+	var erabIDKeys []string
+	var retBearers []uenib.Bearer
+
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
+
+	erabIDs, err := reader.getErabIDs(id)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, erabID := range erabIDs {
+		erabIDKeys = append(erabIDKeys, internal.GetErabAllDbKeys(id, erabID)...)
+	}
+
+	if q, err = reader.newGetQuery(ueID, erabIDKeys); err != nil {
+		return nil, err
+	}
+
+	for _, erabID := range erabIDs {
+		var br uenib.Bearer
+		br.ErabID = erabID
+		if br.DrbID, err = q.getKeyUint32Value(id, internal.DbKeyErabDrbID(id, erabID)); err != nil {
+			return nil, err
+		}
+		if br.ArpPL, err = q.getKeyUint32Value(id, internal.DbKeyErabQosArpPL(id, erabID)); err != nil {
+			return nil, err
+		}
+		if br.Qci, err = q.getKeyUint32Value(id, internal.DbKeyErabQosQci(id, erabID)); err != nil {
+			return nil, err
+		}
+		if br.S1ULGtpTE.Address, err = q.getKeyByteSliceValue(id, internal.DbKeyErabS1UlGtpTendpAddr(id, erabID)); err != nil {
+			return nil, err
+		}
+		if br.S1ULGtpTE.Teid, err = q.getKeyByteSliceValue(id, internal.DbKeyErabS1UlGtpTendpTeid(id, erabID)); err != nil {
+			return nil, err
+		}
+		retBearers = append(retBearers, br)
+	}
+	return retBearers, err
 }
 
 //GetErabS1ULGtpTE returns UE bearer's S1 uplink GTP tunnel endpoint.
 //Parameter ueID identifies User equipment (UE).
 //Parameter erabID identifies bearer.
 func (reader *Reader) GetErabS1ULGtpTE(ueID *uenib.UeID, erabID uenib.ErabID) (*uenib.TunnelEndpoint, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return &uenib.TunnelEndpoint{}, err
+	var q *query
+	var retTEp uenib.TunnelEndpoint
+
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
+
+	addrKey := internal.DbKeyErabS1UlGtpTendpAddr(id, erabID)
+	teidKey := internal.DbKeyErabS1UlGtpTendpTeid(id, erabID)
+
+	if q, err = reader.newGetQuery(ueID, []string{addrKey, teidKey}); err != nil {
+		return nil, err
+	}
+
+	if retTEp.Address, err = q.getKeyByteSliceValue(ueID, addrKey); err != nil {
+		return nil, err
+	}
+	if retTEp.Teid, err = q.getKeyByteSliceValue(ueID, teidKey); err != nil {
+		return nil, err
+	}
+	return &retTEp, err
 }
 
 //GetErabS1ULGtpTEAddr returns UE bearer's transport layer address of an S1 uplink GTP tunnel endpoint.
 //Parameter ueID identifies User equipment (UE).
 //Parameter erabID identifies bearer.
 func (reader *Reader) GetErabS1ULGtpTEAddr(ueID *uenib.UeID, erabID uenib.ErabID) ([]byte, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return make([]byte, 0), err
+	var q *query
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
+
+	addrKey := internal.DbKeyErabS1UlGtpTendpAddr(id, erabID)
+
+	if q, err = reader.newGetQuery(ueID, []string{addrKey}); err != nil {
+		return nil, err
+	}
+
+	return q.getKeyByteSliceValue(ueID, addrKey)
 }
 
 //GetErabS1ULGtpTETeid returns UE bearer's GTP tunnel endpoint ID (TEID) of an S1 uplink GTP tunnel endpoint.
 //Parameter ueID identifies User equipment (UE).
 //Parameter erabID identifies bearer.
 func (reader *Reader) GetErabS1ULGtpTETeid(ueID *uenib.UeID, erabID uenib.ErabID) ([]byte, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return make([]byte, 0), err
-}
+	var q *query
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return nil, err
+	}
 
-//GetErabQosQci returns UE bearer's QoS Class Identifier (QCI).
-//Parameter ueID identifies User equipment (UE).
-//Parameter erabID identifies bearer.
-func (reader *Reader) GetErabQosQci(ueID *uenib.UeID, erabID uenib.ErabID) (uint32, error) {
-	var err error
-	//@todo Add value reading from UE-NIB database.
-	return uint32(0), err
+	teidKey := internal.DbKeyErabS1UlGtpTendpTeid(id, erabID)
+
+	if q, err = reader.newGetQuery(ueID, []string{teidKey}); err != nil {
+		return nil, err
+	}
+
+	return q.getKeyByteSliceValue(ueID, teidKey)
 }
 
 //GetErabQosArpPL returns UE bearer's QoS Allocation and Retention Priority (ARP) priority level (PL)
 //Parameter ueID identifies User equipment (UE).
 //Parameter erabID identifies bearer.
 func (reader *Reader) GetErabQosArpPL(ueID *uenib.UeID, erabID uenib.ErabID) (uint32, error) {
+	var q *query
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return uint32(0), err
+	}
+
+	arpPLKey := internal.DbKeyErabQosArpPL(id, erabID)
+
+	if q, err = reader.newGetQuery(ueID, []string{arpPLKey}); err != nil {
+		return uint32(0), err
+	}
+
+	return q.getKeyUint32Value(ueID, arpPLKey)
+}
+
+//GetErabQosQci returns UE bearer's QoS Class Identifier (QCI).
+//Parameter ueID identifies User equipment (UE).
+//Parameter erabID identifies bearer.
+func (reader *Reader) GetErabQosQci(ueID *uenib.UeID, erabID uenib.ErabID) (uint32, error) {
+	var q *query
+	id, err := reader.validateUeIDAndResolveENbX2ApID(ueID)
+	if err != nil {
+		return uint32(0), err
+	}
+
+	qciKey := internal.DbKeyErabQosQci(id, erabID)
+
+	if q, err = reader.newGetQuery(ueID, []string{qciKey}); err != nil {
+		return uint32(0), err
+	}
+
+	return q.getKeyUint32Value(ueID, qciKey)
+}
+
+func (reader *Reader) validateUeIDAndResolveENbX2ApID(ueID *uenib.UeID) (*uenib.UeID, error) {
 	var err error
-	//@todo Add value reading from UE-NIB database.
-	return uint32(0), err
+	if err = validateUe(ueID); err != nil {
+		return nil, err
+	}
+	//Make own copy of UeID not to alter the original ueID received in UE-NIB Reader API.
+	id := *ueID
+
+	if len(id.ENbUeX2ApID) == 0 {
+		key := internal.DbKeyUeMapGNbToENbUeX2ApID(ueID)
+		if id.ENbUeX2ApID, err = reader.resolveENbX2ApID(ueID, key); err != nil {
+			return nil, err
+		}
+	}
+	return &id, err
+}
+
+func (reader *Reader) resolveENbX2ApID(ueID *uenib.UeID, key string) (string, error) {
+	q, err := reader.newGetQuery(ueID, []string{key})
+	if err != nil {
+		return "", err
+	}
+
+	return q.getKeyStringValue(ueID, key)
+}
+
+func (reader *Reader) getErabIDs(ueID *uenib.UeID) ([]uenib.ErabID, error) {
+	var strVal string
+
+	key := internal.DbKeyUeErabIDs(ueID)
+
+	q, err := reader.newGetQuery(ueID, []string{key})
+	if err != nil {
+		return nil, err
+	}
+
+	if strVal, err = q.getKeyStringValue(ueID, key); err != nil {
+		return nil, err
+	}
+	return parseErabIDsStringToErabIDSlice(ueID, strVal)
+}
+
+func (reader *Reader) newGetQuery(ueID *uenib.UeID, keys []string) (*query, error) {
+	var err error
+	q := &query{}
+	if q.kvMap, err = reader.db.Get(keys); err != nil {
+		return nil, toBackendError(ueID, err)
+	}
+	return q, err
+}
+
+type query struct {
+	kvMap map[string]interface{}
+}
+
+func (q *query) getKeyStringValue(ueID *uenib.UeID, key string) (string, error) {
+	var err error
+	if val, ok := q.kvMap[key]; ok {
+		if val == nil {
+			return "", toValueNotFoundFailure(ueID, key)
+		}
+		return val.(string), err
+	}
+	return "", toValueNotFoundFailure(ueID, key)
+}
+
+func (q *query) getKeyUint32Value(ueID *uenib.UeID, key string) (uint32, error) {
+	strVal, err := q.getKeyStringValue(ueID, key)
+	if err != nil {
+		return uint32(0), err
+	}
+	return parseStringToUint32(ueID, strVal)
+}
+
+func (q *query) getKeyByteSliceValue(ueID *uenib.UeID, key string) ([]byte, error) {
+	strVal, err := q.getKeyStringValue(ueID, key)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(strVal), err
+}
+
+func toValueNotFoundFailure(ueID *uenib.UeID, key string) *valueNotFoundFailure {
+	return &valueNotFoundFailure{ueID: *ueID, name: key, temporary: true}
+}
+
+func toBackendError(ueID *uenib.UeID, err error) *backendError {
+	return &backendError{ueID: *ueID, err: err.Error(), temporary: true}
+}
+
+func toValidationError(ueID *uenib.UeID, err error) *validationError {
+	return &validationError{ueID: *ueID, err: err.Error()}
+}
+
+func validateUe(ueID *uenib.UeID) error {
+	var err error
+	if len(ueID.GNb) == 0 {
+		err = toValidationError(ueID, errors.New(fmt.Sprintf("%s :: missing GNb", ueID.String())))
+		return err
+	}
+
+	if len(ueID.GNbUeX2ApID) == 0 && len(ueID.ENbUeX2ApID) == 0 {
+		err = toValidationError(ueID, errors.New(fmt.Sprintf("%s :: missing both UeX2ApIDs", ueID.String())))
+		return err
+	}
+	return err
+}
+
+func parseStringToUint32(ueID *uenib.UeID, str string) (uint32, error) {
+	val, err := strconv.ParseUint(str, 10, 32)
+	if err != nil {
+		return uint32(0), toValidationError(ueID, err)
+	}
+	return uint32(val), err
+}
+
+func parseErabIDsStringToErabIDSlice(ueID *uenib.UeID, strList string) ([]uenib.ErabID, error) {
+	var err error
+	var uIntVal uint32
+	strVals := strings.Split(strList, ",")
+	erabVals := make([]uenib.ErabID, len(strVals))
+
+	for i, s := range strVals {
+		if uIntVal, err = parseStringToUint32(ueID, s); err != nil {
+			return nil, err
+		}
+		erabVals[i] = uenib.ErabID(uIntVal)
+	}
+	return erabVals, err
 }

--- a/pkg/uenibreader/query_test.go
+++ b/pkg/uenibreader/query_test.go
@@ -8,96 +8,1339 @@
 package uenibreader_test
 
 import (
+	"errors"
+	"fmt"
 	"github.com/nokia/ue-nib-library/pkg/uenib"
+	"github.com/nokia/ue-nib-library/pkg/uenibreader"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 var someUeID uenib.UeID
+var anotherUeID uenib.UeID
 var someErabID uenib.ErabID
+var anotherErabID uenib.ErabID
+var someDbKeyGNbUeX2ApID string
+var someDbKeyENbUeX2ApID string
+var someDbKeyPsCellPci string
+var someDbKeyPsCellSsbFreq string
+var someDbKeyUeStateEvent string
+var someDbKeyUeStateCause string
+var someDbKeyBearerIDs string
+var someDbKeyBearerDrbID string
+var someDbKeyBearerS1ULTepAddr string
+var someDbKeyBearerS1ULTepTeid string
+var someDbKeyBearerArpPL string
+var someDbKeyBearerQci string
+
+var anotherDbKeyBearerDrbID string
+var anotherDbKeyBearerS1ULTepAddr string
+var anotherDbKeyBearerS1ULTepTeid string
+var anotherDbKeyBearerArpPL string
+var anotherDbKeyBearerQci string
 
 func init() {
 	someUeID = uenib.UeID{
 		GNb:         "somegnb:310-410-b5c67788",
-		GNbUeX2ApID: "200",
 		ENbUeX2ApID: "100",
 	}
+	anotherUeID = uenib.UeID{
+		GNb:         "somegnb:310-410-b5c67788",
+		GNbUeX2ApID: "200",
+	}
 	someErabID = 1000
+	anotherErabID = 2000
+
+	someDbKeyENbUeX2ApID = someUeID.GNb + "," + anotherUeID.GNbUeX2ApID + ",UEMAP_ENBUEX2APID"
+	someDbKeyGNbUeX2ApID = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UEMAP_GNBUEX2APID"
+	someDbKeyPsCellPci = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_PSCELL_PCI"
+	someDbKeyPsCellSsbFreq = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_PSCELL_FREQ"
+	someDbKeyUeStateEvent = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_STATE_EVENT"
+	someDbKeyUeStateCause = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_STATE_CAUSE"
+	someDbKeyBearerIDs = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_ERAB_IDS"
+
+	someDbKeyBearerDrbID = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(someErabID) + ",UE_ERAB_DRB_ID"
+	someDbKeyBearerS1ULTepAddr = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(someErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
+	someDbKeyBearerS1ULTepTeid = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(someErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
+	someDbKeyBearerArpPL = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(someErabID) + ",UE_ERAB_QOS_ARP_PL"
+	someDbKeyBearerQci = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(someErabID) + ",UE_ERAB_QOS_QCI"
+
+	anotherDbKeyBearerDrbID = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(anotherErabID) + ",UE_ERAB_DRB_ID"
+	anotherDbKeyBearerS1ULTepAddr = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(anotherErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
+	anotherDbKeyBearerS1ULTepTeid = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(anotherErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
+	anotherDbKeyBearerArpPL = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(anotherErabID) + ",UE_ERAB_QOS_ARP_PL"
+	anotherDbKeyBearerQci = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+		fmt.Sprint(anotherErabID) + ",UE_ERAB_QOS_QCI"
+}
+
+func getTestCellEntry(pci uint32, ssbFreq uint32) *uenib.Cell {
+	return &uenib.Cell{
+		Pci:     pci,
+		SsbFreq: ssbFreq,
+	}
+}
+
+func getTestStateEntry(event string, cause string) *uenib.UeState {
+	return &uenib.UeState{
+		Event: event,
+		Cause: cause,
+	}
+}
+
+func getTestStateEntryOnlyEvent(event string) *uenib.UeState {
+	return &uenib.UeState{
+		Event: event,
+	}
+}
+
+func getTestErabIDs(erabID1 uenib.ErabID, erabID2 uenib.ErabID) []uenib.ErabID {
+	return []uenib.ErabID{erabID1, erabID2}
+}
+
+func getTestErabs() []uenib.Bearer {
+	return []uenib.Bearer{
+		uenib.Bearer{
+			ErabID: 1000,
+			DrbID:  150,
+			ArpPL:  1,
+			Qci:    10,
+			S1ULGtpTE: uenib.TunnelEndpoint{
+				Address: []byte("10.20.30.40"),
+				Teid:    []byte("1999"),
+			},
+		},
+		uenib.Bearer{
+			ErabID: 2000,
+			DrbID:  250,
+			ArpPL:  2,
+			Qci:    20,
+			S1ULGtpTE: uenib.TunnelEndpoint{
+				Address: []byte("20.20.30.40"),
+				Teid:    []byte("2999"),
+			},
+		},
+	}
+}
+
+func expectDbError(t *testing.T, err error, expCause string) {
+	assert.NotNil(t, err)
+	uenibError, ok := err.(uenibreader.Error)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, uenibError.Temporary())
+	assert.Equal(t, true, uenibreader.IsBackendError(err))
+	assert.Equal(t, false, uenibreader.IsValueNotFoundFailure(err))
+	assert.Equal(t, false, uenibreader.IsValidationError(err))
+	assert.Equal(t, false, uenibreader.IsInternalError(err))
+	assert.Contains(t, err.Error(), "database backend error: "+expCause)
+}
+
+func expectValueNotFoundFailure(t *testing.T, err error, name string) {
+	assert.NotNil(t, err)
+	uenibError, ok := err.(uenibreader.Error)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, true, uenibError.Temporary())
+	assert.Equal(t, true, uenibreader.IsValueNotFoundFailure(err))
+	assert.Equal(t, false, uenibreader.IsBackendError(err))
+	assert.Equal(t, false, uenibreader.IsValidationError(err))
+	assert.Equal(t, false, uenibreader.IsInternalError(err))
+	assert.Contains(t, err.Error(), "value of DB key '"+name+"' not found")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func expectValidationError(t *testing.T, err error, name string) {
+	assert.NotNil(t, err)
+	uenibError, ok := err.(uenibreader.Error)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, false, uenibError.Temporary())
+	assert.Equal(t, true, uenibreader.IsValidationError(err))
+	assert.Equal(t, false, uenibreader.IsValueNotFoundFailure(err))
+	assert.Equal(t, false, uenibreader.IsBackendError(err))
+	assert.Equal(t, false, uenibreader.IsInternalError(err))
+	assert.Contains(t, err.Error(), "validation error:")
+	assert.Contains(t, err.Error(), name)
+}
+
+func getTestTunnelEndpointEntry(addr string, teid string) *uenib.TunnelEndpoint {
+	return &uenib.TunnelEndpoint{
+		Address: []byte(addr),
+		Teid:    []byte(teid),
+	}
 }
 
 func TestGetMeNbUEX2APIDSuccess(t *testing.T) {
-	_, i := setup()
-	ret, err := i.GetMeNbUEX2APID(&someUeID)
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+
+	ret, err := i.GetMeNbUEX2APID(&anotherUeID)
+
 	assert.Nil(t, err)
+	assert.Equal(t, uint32(100), ret)
+}
+
+func TestGetMeNbUEX2APIDReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetMeNbUEX2APID(
+		&uenib.UeID{
+			GNbUeX2ApID: "200",
+			ENbUeX2ApID: "100",
+		},
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetMeNbUEX2APIDReturnsErrorIfNoGnbX2ApIDInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetMeNbUEX2APID(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+	)
+
+	expectValidationError(t, err, "GNbUeX2ApID")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetMeNbUEX2APIDReturnsErrorIfDbKeyNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{}, nil,
+	).Once()
+
+	ret, err := i.GetMeNbUEX2APID(&anotherUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyENbUeX2ApID)
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetMeNbUEX2APIDReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: nil}, nil,
+	).Once()
+
+	ret, err := i.GetMeNbUEX2APID(&anotherUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyENbUeX2ApID)
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetMeNbUEX2APIDReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetMeNbUEX2APID(&anotherUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetMeNbUEX2APIDReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "IamNotInt"}, nil,
+	).Once()
+
+	ret, err := i.GetMeNbUEX2APID(&anotherUeID)
+
+	expectValidationError(t, err, "IamNotInt")
 	assert.Equal(t, uint32(0), ret)
 }
 
 func TestGetSgNbUEX2APIDSuccess(t *testing.T) {
-	_, i := setup()
+	m, i := setup()
+	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyGNbUeX2ApID: "200"}, nil,
+	).Once()
+
 	ret, err := i.GetSgNbUEX2APID(&someUeID)
+
 	assert.Nil(t, err)
+	assert.Equal(t, uint32(200), ret)
+}
+
+func TestGetSgNbUEX2APIDReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetSgNbUEX2APID(
+		&uenib.UeID{
+			GNbUeX2ApID: "200",
+			ENbUeX2ApID: "100",
+		},
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetSgNbUEX2APIDReturnsErrorIfNoEnbX2ApIDInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetSgNbUEX2APID(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+	)
+
+	expectValidationError(t, err, "ENbUeX2ApID")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetSgNbUEX2APIDReturnsErrorIfDbKeyNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+		map[string]interface{}{}, nil,
+	).Once()
+
+	ret, err := i.GetSgNbUEX2APID(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyGNbUeX2ApID)
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetSgNbUEX2APIDReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyGNbUeX2ApID: nil}, nil,
+	).Once()
+
+	ret, err := i.GetSgNbUEX2APID(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyGNbUeX2ApID)
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetSgNbUEX2APIDReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetSgNbUEX2APID(&someUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetSgNbUEX2APIDReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyGNbUeX2ApID: "IamNotInt"}, nil,
+	).Once()
+
+	ret, err := i.GetSgNbUEX2APID(&someUeID)
+
+	expectValidationError(t, err, "IamNotInt")
 	assert.Equal(t, uint32(0), ret)
 }
 
 func TestGetPsCellSuccess(t *testing.T) {
-	_, i := setup()
+	m, i := setup()
+	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+		map[string]interface{}{someDbKeyPsCellPci: "10", someDbKeyPsCellSsbFreq: "20"}, nil,
+	).Once()
+
 	ret, err := i.GetPsCell(&someUeID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, uenib.Cell{}, *ret)
+	assert.Equal(t, getTestCellEntry(10, 20), ret)
 }
 
-func TestGetUeStateSuccess(t *testing.T) {
+func TestGetPsCellWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+		map[string]interface{}{someDbKeyPsCellPci: "10", someDbKeyPsCellSsbFreq: "20"}, nil,
+	).Once()
+
+	ret, err := i.GetPsCell(&anotherUeID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, getTestCellEntry(10, 20), ret)
+}
+
+func TestGetPsCellReturnsErrorIfNoGNbInUeID(t *testing.T) {
 	_, i := setup()
+
+	ret, err := i.GetPsCell(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetPsCellReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetPsCell(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetPsCellReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(nil, dbError).Once()
+
+	ret, err := i.GetPsCell(&someUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetPsCellWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetPsCell(&anotherUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetPsCellReturnsErrorIfPciDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+		map[string]interface{}{someDbKeyPsCellPci: nil, someDbKeyPsCellSsbFreq: "20"}, nil,
+	).Once()
+
+	ret, err := i.GetPsCell(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyPsCellPci)
+	assert.Nil(t, ret)
+}
+
+func TestGetPsCellReturnsErrorIfSsbFreqDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+		map[string]interface{}{someDbKeyPsCellPci: "10", someDbKeyPsCellSsbFreq: nil}, nil,
+	).Once()
+
+	ret, err := i.GetPsCell(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyPsCellSsbFreq)
+	assert.Nil(t, ret)
+}
+
+func TestGetStateSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+		map[string]interface{}{
+			someDbKeyUeStateEvent: "2020-04-30T09:02:39.364571+03:00;SGNB-RECONF-CMPLT",
+			someDbKeyUeStateCause: nil,
+		}, nil,
+	).Once()
+
 	ret, err := i.GetState(&someUeID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, uenib.UeState{}, *ret)
+	assert.Equal(t, getTestStateEntryOnlyEvent("2020-04-30T09:02:39.364571+03:00;SGNB-RECONF-CMPLT"), ret)
 }
 
-func TestGetBearersSuccess(t *testing.T) {
-	_, i := setup()
-	ret, err := i.GetBearers(&someUeID)
+func TestGetStateWithCauseSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+		map[string]interface{}{
+			someDbKeyUeStateEvent: "2020-04-30T09:02:39.364571+03:00;SGNB-ADD-REQ-REJ",
+			someDbKeyUeStateCause: "SGNB-ADD-REQ-REJ;radioNetwork;no_radio_resources_available",
+		}, nil,
+	).Once()
+
+	ret, err := i.GetState(&someUeID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, make([]uenib.Bearer, 0), ret)
+	assert.Equal(t, getTestStateEntry(
+		"2020-04-30T09:02:39.364571+03:00;SGNB-ADD-REQ-REJ",
+		"SGNB-ADD-REQ-REJ;radioNetwork;no_radio_resources_available",
+	), ret)
+}
+
+func TestGeStateWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+		map[string]interface{}{
+			someDbKeyUeStateEvent: "STATE-123",
+			someDbKeyUeStateCause: nil,
+		}, nil,
+	).Once()
+
+	ret, err := i.GetState(&anotherUeID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, getTestStateEntryOnlyEvent("STATE-123"), ret)
+}
+
+func TestGetStateReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetState(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetStateReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetState(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetStateReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(nil, dbError).Once()
+
+	ret, err := i.GetState(&someUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetStateWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetState(&anotherUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetStateReturnsErrorIfEventDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+		map[string]interface{}{
+			someDbKeyUeStateEvent: nil,
+			someDbKeyUeStateCause: "something",
+		}, nil,
+	).Once()
+
+	ret, err := i.GetState(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyUeStateEvent)
+	assert.Nil(t, ret)
 }
 
 func TestGetBearerIDsSuccess(t *testing.T) {
-	_, i := setup()
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "1000,2000"}, nil,
+	).Once()
+
 	ret, err := i.GetBearerIDs(&someUeID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, make([]uenib.ErabID, 0), ret)
+	assert.Equal(t, getTestErabIDs(1000, 2000), ret)
 }
 
-func TestGetS1ULGtpTESuccess(t *testing.T) {
+func TestGetBearerIDsWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "1000,2000"}, nil,
+	).Once()
+
+	ret, err := i.GetBearerIDs(&anotherUeID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, getTestErabIDs(1000, 2000), ret)
+}
+
+func TestGetBearerIDsReturnsErrorIfNoGNbInUeID(t *testing.T) {
 	_, i := setup()
+
+	ret, err := i.GetBearerIDs(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearerIDsReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetBearerIDs(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearerIDsReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(nil, dbError).Once()
+
+	ret, err := i.GetBearerIDs(&someUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearerIDsWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetBearerIDs(&anotherUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearerIDsReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: nil}, nil,
+	).Once()
+
+	ret, err := i.GetBearerIDs(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerIDs)
+	assert.Nil(t, ret)
+}
+
+func TestGetBearerIDsReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "IamNotInt"}, nil,
+	).Once()
+
+	ret, err := i.GetBearerIDs(&someUeID)
+
+	expectValidationError(t, err, "IamNotInt")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "1000,2000"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerDrbID,
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+		someDbKeyBearerArpPL,
+		someDbKeyBearerQci,
+		anotherDbKeyBearerDrbID,
+		anotherDbKeyBearerS1ULTepAddr,
+		anotherDbKeyBearerS1ULTepTeid,
+		anotherDbKeyBearerArpPL,
+		anotherDbKeyBearerQci,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerDrbID:          "150",
+			someDbKeyBearerS1ULTepAddr:    "10.20.30.40",
+			someDbKeyBearerS1ULTepTeid:    "1999",
+			someDbKeyBearerArpPL:          "1",
+			someDbKeyBearerQci:            "10",
+			anotherDbKeyBearerDrbID:       "250",
+			anotherDbKeyBearerS1ULTepAddr: "20.20.30.40",
+			anotherDbKeyBearerS1ULTepTeid: "2999",
+			anotherDbKeyBearerArpPL:       "2",
+			anotherDbKeyBearerQci:         "20",
+		}, nil).Once()
+
+	ret, err := i.GetBearers(&someUeID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, getTestErabs(), ret)
+}
+
+func TestGetBearersReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetBearers(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetBearers(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "1000"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerDrbID,
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+		someDbKeyBearerArpPL,
+		someDbKeyBearerQci,
+	}).Return(nil, dbError).Once()
+
+	ret, err := i.GetBearers(&someUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersReturnsErrorIfBearerIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(nil, dbError).Once()
+
+	ret, err := i.GetBearers(&someUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetBearers(&anotherUeID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "1000"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerDrbID,
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+		someDbKeyBearerArpPL,
+		someDbKeyBearerQci,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerDrbID: nil,
+		}, nil).Once()
+
+	ret, err := i.GetBearers(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerDrbID)
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersReturnsErrorIfBearerIDDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: nil}, nil,
+	).Once()
+
+	ret, err := i.GetBearers(&someUeID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerIDs)
+	assert.Nil(t, ret)
+}
+
+func TestGetBearersReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+		map[string]interface{}{someDbKeyBearerIDs: "1000"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerDrbID,
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+		someDbKeyBearerArpPL,
+		someDbKeyBearerQci,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerDrbID: "IamNotInt",
+		}, nil).Once()
+
+	ret, err := i.GetBearers(&someUeID)
+
+	expectValidationError(t, err, "IamNotInt")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTESuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: "10.20.30.40",
+			someDbKeyBearerS1ULTepTeid: "1999",
+		}, nil).Once()
+
 	ret, err := i.GetErabS1ULGtpTE(&someUeID, someErabID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, uenib.TunnelEndpoint{}, *ret)
+	assert.Equal(t, getTestTunnelEndpointEntry("10.20.30.40", "1999"), ret)
 }
 
-func TestGetS1ULGtpTEAddrSuccess(t *testing.T) {
+func TestGetErabS1ULGtpTEWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: "10.20.30.40",
+			someDbKeyBearerS1ULTepTeid: "1999",
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTE(&someUeID, someErabID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, getTestTunnelEndpointEntry("10.20.30.40", "1999"), ret)
+}
+
+func TestGetErabS1ULGtpTEReturnsErrorIfNoGNbInUeID(t *testing.T) {
 	_, i := setup()
+
+	ret, err := i.GetErabS1ULGtpTE(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabS1ULGtpTE(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabS1ULGtpTE(&someUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabS1ULGtpTE(&anotherUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEReturnsErrorIfAddressDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: nil,
+			someDbKeyBearerS1ULTepTeid: "1999",
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTE(&someUeID, someErabID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerS1ULTepAddr)
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEReturnsErrorIfTeidDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: "10.20.30.40",
+			someDbKeyBearerS1ULTepTeid: nil,
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTE(&someUeID, someErabID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerS1ULTepTeid)
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEAddrSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: "10.20.30.40",
+		}, nil).Once()
+
 	ret, err := i.GetErabS1ULGtpTEAddr(&someUeID, someErabID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, make([]byte, 0), ret)
+	assert.Equal(t, []byte("10.20.30.40"), ret)
 }
 
-func TestGetS1ULGtpTETeidSuccess(t *testing.T) {
+func TestGetErabS1ULGtpTEAddrWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: "10.20.30.40",
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTEAddr(&someUeID, someErabID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("10.20.30.40"), ret)
+}
+
+func TestGetErabS1ULGtpTEAddrReturnsErrorIfNoGNbInUeID(t *testing.T) {
 	_, i := setup()
+
+	ret, err := i.GetErabS1ULGtpTEAddr(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEAddrReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabS1ULGtpTEAddr(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEAddrReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+	}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabS1ULGtpTEAddr(&someUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEAddrWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabS1ULGtpTEAddr(&anotherUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTEAddrReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepAddr,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepAddr: nil,
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTEAddr(&someUeID, someErabID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerS1ULTepAddr)
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTETeidSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepTeid: "1999",
+		}, nil).Once()
+
 	ret, err := i.GetErabS1ULGtpTETeid(&someUeID, someErabID)
+
 	assert.Nil(t, err)
-	assert.Equal(t, make([]byte, 0), ret)
+	assert.Equal(t, []byte("1999"), ret)
 }
 
-func TestGetQosQciSuccess(t *testing.T) {
-	_, i := setup()
-	ret, err := i.GetErabQosQci(&someUeID, someErabID)
+func TestGetErabS1ULGtpTETeidWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepTeid: "1999",
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTETeid(&someUeID, someErabID)
+
 	assert.Nil(t, err)
+	assert.Equal(t, []byte("1999"), ret)
+}
+
+func TestGetErabS1ULGtpTETeidReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabS1ULGtpTETeid(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTETeidReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabS1ULGtpTETeid(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTETeidReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabS1ULGtpTETeid(&someUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTETeidWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabS1ULGtpTETeid(&anotherUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Nil(t, ret)
+}
+
+func TestGetErabS1ULGtpTETeidReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerS1ULTepTeid,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerS1ULTepTeid: nil,
+		}, nil).Once()
+
+	ret, err := i.GetErabS1ULGtpTETeid(&someUeID, someErabID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerS1ULTepTeid)
+	assert.Nil(t, ret)
+}
+
+func TestGetErabQosArpPLSuccessSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerArpPL,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerArpPL: "1",
+		}, nil).Once()
+
+	ret, err := i.GetErabQosArpPL(&someUeID, someErabID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(1), ret)
+}
+
+func TestGetErabQosArpPLWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerArpPL,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerArpPL: "1",
+		}, nil).Once()
+
+	ret, err := i.GetErabQosArpPL(&someUeID, someErabID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(1), ret)
+}
+
+func TestGetErabQosArpPLReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabQosArpPL(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "GNb")
 	assert.Equal(t, uint32(0), ret)
 }
 
-func TestGetQosArpPLSuccess(t *testing.T) {
+func TestGetErabQosArpPLReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 	_, i := setup()
+
+	ret, err := i.GetErabQosArpPL(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosArpPLReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{
+		someDbKeyBearerArpPL,
+	}).Return(nil, dbError).Once()
+
 	ret, err := i.GetErabQosArpPL(&someUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosArpPLWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabQosArpPL(&anotherUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosArpPLReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerArpPL,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerArpPL: nil,
+		}, nil).Once()
+
+	ret, err := i.GetErabQosArpPL(&someUeID, someErabID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerArpPL)
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosQciSuccessSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerQci,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerQci: "10",
+		}, nil).Once()
+
+	ret, err := i.GetErabQosQci(&someUeID, someErabID)
+
 	assert.Nil(t, err)
+	assert.Equal(t, uint32(10), ret)
+}
+
+func TestGetErabQosQciWithGnbX2ApIDSuccess(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
+	).Once()
+	m.On("Get", []string{
+		someDbKeyBearerQci,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerQci: "10",
+		}, nil).Once()
+
+	ret, err := i.GetErabQosQci(&someUeID, someErabID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(10), ret)
+}
+
+func TestGetErabQosQciReturnsErrorIfNoGNbInUeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabQosQci(
+		&uenib.UeID{
+			ENbUeX2ApID: "100",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "GNb")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosQciReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
+	_, i := setup()
+
+	ret, err := i.GetErabQosQci(
+		&uenib.UeID{
+			GNb: "somegnb:310-410-b5c67788",
+		},
+		someErabID,
+	)
+
+	expectValidationError(t, err, "both UeX2ApIDs")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosQciReturnsErrorIfDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{
+		someDbKeyBearerQci,
+	}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabQosQci(&someUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosQciWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
+	m, i := setup()
+	dbError := errors.New("Some DB Error")
+	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+
+	ret, err := i.GetErabQosQci(&anotherUeID, someErabID)
+
+	expectDbError(t, err, "Some DB Error")
+	assert.Equal(t, uint32(0), ret)
+}
+
+func TestGetErabQosQciReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
+	m, i := setup()
+	m.On("Get", []string{
+		someDbKeyBearerQci,
+	}).Return(
+		map[string]interface{}{
+			someDbKeyBearerQci: nil,
+		}, nil).Once()
+
+	ret, err := i.GetErabQosQci(&someUeID, someErabID)
+
+	expectValueNotFoundFailure(t, err, someDbKeyBearerQci)
 	assert.Equal(t, uint32(0), ret)
 }

--- a/pkg/uenibreader/reader.go
+++ b/pkg/uenibreader/reader.go
@@ -5,6 +5,7 @@
    SPDX-License-Identifier: BSD-3-Clause-Clear
 */
 
+//Package uenibreader implements UE-NIB database event subscription and data query functions.
 package uenibreader
 
 import (
@@ -39,7 +40,6 @@ func NewReader() *Reader {
 func (reader *Reader) Close() error {
 	err := reader.db.Close()
 	if err != nil {
-		//@todo logging
 		return newBackendError(err.Error())
 	}
 	return err

--- a/pkg/uenibreader/reader_test.go
+++ b/pkg/uenibreader/reader_test.go
@@ -65,6 +65,6 @@ func TestCloseDbBackendFailure(t *testing.T) {
 	uenibFailure, ok := err.(uenibreader.Error)
 	assert.Equal(t, true, ok)
 	assert.Equal(t, true, uenibFailure.Temporary())
-	assert.Contains(t, uenibFailure.Error(), "UE-NIB database backend error: Some DB Backend Error")
+	assert.Contains(t, uenibFailure.Error(), "database backend error: Some DB Backend Error")
 	m.AssertExpectations(t)
 }


### PR DESCRIPTION
Add first version of UE-NIB reader implementation to query UE state,
PsCell, MeNb UE X2AP ID, SgNb UE X2 AP ID, UE bearers, bearer S1 UL
tunnel endpoint, bearer QoS QCI and ARP PL.
S1 uplink tunnel change notification event strings are now form of:
  <UE_ID>_<S1UL_TUN_ENDPOINT>_S1UL_TUNNEL_ESTABLISH
  <UE_ID>_<S1UL_TUN_ENDPOINT>_S1UL_TUNNEL_RELEASE
Multiple tunnel endpoints can be included to the same event string.