### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # ue-nib-library
 A library that works together with Nokia’s UEEC xApp
+
+
+## License
+
+This project is licensed under the BSD-3-Clause-Clear license - see the [LICENSE](https://github.com/nokia/ue-nib-library/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.