### PR TITLE
Add GNB-ID to SDL namespace and bump SDL v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/nokia/ue-nib-library
 go 1.12
 
 require (
-	gerrit.o-ran-sc.org/r/ric-plt/sdlgo v0.5.3
+	gerrit.o-ran-sc.org/r/ric-plt/sdlgo v0.7.0
 	github.com/stretchr/testify v1.3.0
 )
 
-replace gerrit.o-ran-sc.org/r/ric-plt/sdlgo => gerrit.o-ran-sc.org/r/ric-plt/sdlgo.git v0.5.3
+replace gerrit.o-ran-sc.org/r/ric-plt/sdlgo => gerrit.o-ran-sc.org/r/ric-plt/sdlgo.git v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 gerrit.o-ran-sc.org/r/ric-plt/sdlgo.git v0.5.3 h1:xiVHa/mIU3TcXOnXl6abCxbc/Oq/amTEO3ID2VKyEYw=
 gerrit.o-ran-sc.org/r/ric-plt/sdlgo.git v0.5.3/go.mod h1:KCHu4JkWnw2Ro6P747wU9S2t7zxFLmBNCiYvGZo3CHo=
+gerrit.o-ran-sc.org/r/ric-plt/sdlgo.git v0.7.0 h1:mxlBo54jxwHHFmGYzFI+fBIkOGwarQP4dx2KBxQ8ln8=
+gerrit.o-ran-sc.org/r/ric-plt/sdlgo.git v0.7.0/go.mod h1:KCHu4JkWnw2Ro6P747wU9S2t7zxFLmBNCiYvGZo3CHo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/internal/dbkey.go
+++ b/internal/dbkey.go
@@ -13,51 +13,51 @@ import (
 )
 
 func DbKeyUeMapGNbToENbUeX2ApID(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.GNbUeX2ApID + ",UEMAP_ENBUEX2APID"
+	return ueID.GNbUeX2ApID + ",UEMAP_ENBUEX2APID"
 }
 
 func DbKeyUeMapENbToGNbUeX2ApID(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UEMAP_GNBUEX2APID"
+	return ueID.ENbUeX2ApID + ",UEMAP_GNBUEX2APID"
 }
 
 func DbKeyUeStateEvent(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_STATE_EVENT"
+	return ueID.ENbUeX2ApID + ",UE_STATE_EVENT"
 }
 
 func DbKeyUeStateCause(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_STATE_CAUSE"
+	return ueID.ENbUeX2ApID + ",UE_STATE_CAUSE"
 }
 
 func DbKeyPsCellPci(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_PSCELL_PCI"
+	return ueID.ENbUeX2ApID + ",UE_PSCELL_PCI"
 }
 
 func DbKeyPsCellSsbFreq(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_PSCELL_FREQ"
+	return ueID.ENbUeX2ApID + ",UE_PSCELL_FREQ"
 }
 
 func DbKeyUeErabIDs(ueID *uenib.UeID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + ",UE_ERAB_IDS"
+	return ueID.ENbUeX2ApID + ",UE_ERAB_IDS"
 }
 
 func DbKeyErabDrbID(ueID *uenib.UeID, erabID uenib.ErabID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_DRB_ID"
+	return ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_DRB_ID"
 }
 
 func DbKeyErabS1UlGtpTendpAddr(ueID *uenib.UeID, erabID uenib.ErabID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
+	return ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
 }
 
 func DbKeyErabS1UlGtpTendpTeid(ueID *uenib.UeID, erabID uenib.ErabID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
+	return ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
 }
 
 func DbKeyErabQosArpPL(ueID *uenib.UeID, erabID uenib.ErabID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_QOS_ARP_PL"
+	return ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_QOS_ARP_PL"
 }
 
 func DbKeyErabQosQci(ueID *uenib.UeID, erabID uenib.ErabID) string {
-	return ueID.GNb + "," + ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_QOS_QCI"
+	return ueID.ENbUeX2ApID + "," + fmt.Sprint(erabID) + ",UE_ERAB_QOS_QCI"
 }
 
 func GetErabAllDbKeys(ueID *uenib.UeID, erabID uenib.ErabID) []string {
@@ -68,4 +68,8 @@ func GetErabAllDbKeys(ueID *uenib.UeID, erabID uenib.ErabID) []string {
 		DbKeyErabQosArpPL(ueID, erabID),
 		DbKeyErabQosQci(ueID, erabID),
 	}
+}
+
+func GetUeNibNs(gNb string) string {
+	return "uenib/" + gNb
 }

--- a/pkg/uenibreader/event.go
+++ b/pkg/uenibreader/event.go
@@ -9,6 +9,7 @@ package uenibreader
 
 import (
 	"fmt"
+	"github.com/nokia/ue-nib-library/internal"
 	"github.com/nokia/ue-nib-library/pkg/uenib"
 	"strconv"
 	"strings"
@@ -131,7 +132,8 @@ func (reader *Reader) SubscribeEvents(gNbs []string, eventCategories []EventCate
 				return newValidationError("Unknown event category ID: %d", eventCategories[eventCategoriesIndex])
 			}
 			channel := gNbs[gNbIndex] + "_" + eventCategories[eventCategoriesIndex].String()
-			err := reader.db.SubscribeChannel(reader.eventCallback(gNbs[gNbIndex], eventCategories[eventCategoriesIndex], callback), channel)
+			ns := internal.GetUeNibNs(gNbs[gNbIndex])
+			err := reader.db.SubscribeChannel(ns, reader.eventCallback(gNbs[gNbIndex], eventCategories[eventCategoriesIndex], callback), channel)
 			if err != nil {
 				return newBackendError(err.Error())
 			}

--- a/pkg/uenibreader/event_test.go
+++ b/pkg/uenibreader/event_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 )
 
+var someEvNs string
 var someGNb string
 var someEventCategory uenibreader.EventCategory
 var someChannel string
@@ -35,6 +36,7 @@ var expParsedEmptyDcS1ULTunnelEstablishEvent uenibreader.DcEvent
 
 func init() {
 	someGNb = "somegnb:310-410-b5c67788"
+	someEvNs = "uenib/" + someGNb
 	someEventCategory = uenibreader.DualConnectivity
 	someChannel = someGNb + "_" + someEventCategory.String()
 
@@ -140,7 +142,7 @@ func (handler *eventTracker) verify(t *testing.T, expectedCallCount int, expecte
 func TestSubscribeEventsCanSubscribeDualConnectivityEventCategory(t *testing.T) {
 	m, i := setup()
 	eventCategory := uenibreader.DualConnectivity
-	m.On("SubscribeChannel", mock.AnythingOfType("func(string, ...string)"),
+	m.On("SubscribeChannel", someEvNs, mock.AnythingOfType("func(string, ...string)"),
 		[]string{someGNb + "_DUAL_CONNECTIVITY"}).Return(nil).Once()
 
 	err := i.SubscribeEvents([]string{someGNb}, []uenibreader.EventCategory{eventCategory},
@@ -152,7 +154,7 @@ func TestSubscribeEventsCanSubscribeDualConnectivityEventCategory(t *testing.T) 
 func TestSubscribeEventsFailure(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Backend Error")
-	m.On("SubscribeChannel", mock.AnythingOfType("func(string, ...string)"),
+	m.On("SubscribeChannel", someEvNs, mock.AnythingOfType("func(string, ...string)"),
 		[]string{someChannel}).Return(dbError).Once()
 
 	err := i.SubscribeEvents([]string{someGNb}, []uenibreader.EventCategory{someEventCategory},
@@ -169,9 +171,9 @@ func TestSubscribeEventsGetOneEvent(t *testing.T) {
 	m, i := setup()
 	tracker := eventTracker{}
 	var storedSdlCallback func(string, ...string)
-	m.On("SubscribeChannel", mock.AnythingOfType("func(string, ...string)"),
+	m.On("SubscribeChannel", someEvNs, mock.AnythingOfType("func(string, ...string)"),
 		[]string{someChannel}).Run(func(args mock.Arguments) {
-		storedSdlCallback = args.Get(0).(func(string, ...string))
+		storedSdlCallback = args.Get(1).(func(string, ...string))
 	}).Return(nil).Once()
 
 	err := i.SubscribeEvents([]string{someGNb}, []uenibreader.EventCategory{someEventCategory}, tracker.callback)
@@ -198,9 +200,9 @@ func TestSubscribeEventsTwoEventsInOneEvent(t *testing.T) {
 	m, i := setup()
 	tracker := eventTracker{}
 	var storedSdlCallback func(string, ...string)
-	m.On("SubscribeChannel", mock.AnythingOfType("func(string, ...string)"), []string{someChannel}).Run(
+	m.On("SubscribeChannel", someEvNs, mock.AnythingOfType("func(string, ...string)"), []string{someChannel}).Run(
 		func(args mock.Arguments) {
-			storedSdlCallback = args.Get(0).(func(string, ...string))
+			storedSdlCallback = args.Get(1).(func(string, ...string))
 		}).Return(nil).Once()
 	err := i.SubscribeEvents([]string{someGNb}, []uenibreader.EventCategory{someEventCategory}, tracker.callback)
 	assert.Nil(t, err)

--- a/pkg/uenibreader/query.go
+++ b/pkg/uenibreader/query.go
@@ -328,7 +328,8 @@ func (reader *Reader) getErabIDs(ueID *uenib.UeID) ([]uenib.ErabID, error) {
 func (reader *Reader) newGetQuery(ueID *uenib.UeID, keys []string) (*query, error) {
 	var err error
 	q := &query{}
-	if q.kvMap, err = reader.db.Get(keys); err != nil {
+	ns := internal.GetUeNibNs(ueID.GNb)
+	if q.kvMap, err = reader.db.Get(ns, keys); err != nil {
 		return nil, toBackendError(ueID, err)
 	}
 	return q, err

--- a/pkg/uenibreader/query_test.go
+++ b/pkg/uenibreader/query_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 )
 
+var someNs string
+var someGnb string
 var someUeID uenib.UeID
 var anotherUeID uenib.UeID
 var someErabID uenib.ErabID
@@ -40,45 +42,47 @@ var anotherDbKeyBearerArpPL string
 var anotherDbKeyBearerQci string
 
 func init() {
+	someGnb = "somegnb:310-410-b5c67788"
 	someUeID = uenib.UeID{
-		GNb:         "somegnb:310-410-b5c67788",
+		GNb:         someGnb,
 		ENbUeX2ApID: "100",
 	}
 	anotherUeID = uenib.UeID{
-		GNb:         "somegnb:310-410-b5c67788",
+		GNb:         someGnb,
 		GNbUeX2ApID: "200",
 	}
+	someNs = "uenib/" + someGnb
 	someErabID = 1000
 	anotherErabID = 2000
 
-	someDbKeyENbUeX2ApID = someUeID.GNb + "," + anotherUeID.GNbUeX2ApID + ",UEMAP_ENBUEX2APID"
-	someDbKeyGNbUeX2ApID = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UEMAP_GNBUEX2APID"
-	someDbKeyPsCellPci = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_PSCELL_PCI"
-	someDbKeyPsCellSsbFreq = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_PSCELL_FREQ"
-	someDbKeyUeStateEvent = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_STATE_EVENT"
-	someDbKeyUeStateCause = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_STATE_CAUSE"
-	someDbKeyBearerIDs = someUeID.GNb + "," + someUeID.ENbUeX2ApID + ",UE_ERAB_IDS"
+	someDbKeyENbUeX2ApID = anotherUeID.GNbUeX2ApID + ",UEMAP_ENBUEX2APID"
+	someDbKeyGNbUeX2ApID = someUeID.ENbUeX2ApID + ",UEMAP_GNBUEX2APID"
+	someDbKeyPsCellPci = someUeID.ENbUeX2ApID + ",UE_PSCELL_PCI"
+	someDbKeyPsCellSsbFreq = someUeID.ENbUeX2ApID + ",UE_PSCELL_FREQ"
+	someDbKeyUeStateEvent = someUeID.ENbUeX2ApID + ",UE_STATE_EVENT"
+	someDbKeyUeStateCause = someUeID.ENbUeX2ApID + ",UE_STATE_CAUSE"
+	someDbKeyBearerIDs = someUeID.ENbUeX2ApID + ",UE_ERAB_IDS"
 
-	someDbKeyBearerDrbID = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	someDbKeyBearerDrbID = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(someErabID) + ",UE_ERAB_DRB_ID"
-	someDbKeyBearerS1ULTepAddr = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	someDbKeyBearerS1ULTepAddr = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(someErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
-	someDbKeyBearerS1ULTepTeid = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	someDbKeyBearerS1ULTepTeid = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(someErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
-	someDbKeyBearerArpPL = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	someDbKeyBearerArpPL = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(someErabID) + ",UE_ERAB_QOS_ARP_PL"
-	someDbKeyBearerQci = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	someDbKeyBearerQci = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(someErabID) + ",UE_ERAB_QOS_QCI"
 
-	anotherDbKeyBearerDrbID = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	anotherDbKeyBearerDrbID = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(anotherErabID) + ",UE_ERAB_DRB_ID"
-	anotherDbKeyBearerS1ULTepAddr = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	anotherDbKeyBearerS1ULTepAddr = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(anotherErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_ADDR"
-	anotherDbKeyBearerS1ULTepTeid = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	anotherDbKeyBearerS1ULTepTeid = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(anotherErabID) + ",UE_ERAB_S1_UL_GTP_TUNNEL_TEID"
-	anotherDbKeyBearerArpPL = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	anotherDbKeyBearerArpPL = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(anotherErabID) + ",UE_ERAB_QOS_ARP_PL"
-	anotherDbKeyBearerQci = someUeID.GNb + "," + someUeID.ENbUeX2ApID + "," +
+	anotherDbKeyBearerQci = someUeID.ENbUeX2ApID + "," +
 		fmt.Sprint(anotherErabID) + ",UE_ERAB_QOS_QCI"
 }
 
@@ -178,7 +182,7 @@ func getTestTunnelEndpointEntry(addr string, teid string) *uenib.TunnelEndpoint 
 
 func TestGetMeNbUEX2APIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
 
@@ -217,7 +221,7 @@ func TestGetMeNbUEX2APIDReturnsErrorIfNoGnbX2ApIDInUeID(t *testing.T) {
 
 func TestGetMeNbUEX2APIDReturnsErrorIfDbKeyNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{}, nil,
 	).Once()
 
@@ -229,7 +233,7 @@ func TestGetMeNbUEX2APIDReturnsErrorIfDbKeyNotFound(t *testing.T) {
 
 func TestGetMeNbUEX2APIDReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: nil}, nil,
 	).Once()
 
@@ -242,7 +246,7 @@ func TestGetMeNbUEX2APIDReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 func TestGetMeNbUEX2APIDReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetMeNbUEX2APID(&anotherUeID)
 
@@ -252,7 +256,7 @@ func TestGetMeNbUEX2APIDReturnsErrorIfDbQueryFails(t *testing.T) {
 
 func TestGetMeNbUEX2APIDReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "IamNotInt"}, nil,
 	).Once()
 
@@ -264,7 +268,7 @@ func TestGetMeNbUEX2APIDReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 
 func TestGetSgNbUEX2APIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyGNbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyGNbUeX2ApID: "200"}, nil,
 	).Once()
 
@@ -303,7 +307,7 @@ func TestGetSgNbUEX2APIDReturnsErrorIfNoEnbX2ApIDInUeID(t *testing.T) {
 
 func TestGetSgNbUEX2APIDReturnsErrorIfDbKeyNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyGNbUeX2ApID}).Return(
 		map[string]interface{}{}, nil,
 	).Once()
 
@@ -315,7 +319,7 @@ func TestGetSgNbUEX2APIDReturnsErrorIfDbKeyNotFound(t *testing.T) {
 
 func TestGetSgNbUEX2APIDReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyGNbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyGNbUeX2ApID: nil}, nil,
 	).Once()
 
@@ -328,7 +332,7 @@ func TestGetSgNbUEX2APIDReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 func TestGetSgNbUEX2APIDReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyGNbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetSgNbUEX2APID(&someUeID)
 
@@ -338,7 +342,7 @@ func TestGetSgNbUEX2APIDReturnsErrorIfDbQueryFails(t *testing.T) {
 
 func TestGetSgNbUEX2APIDReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyGNbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyGNbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyGNbUeX2ApID: "IamNotInt"}, nil,
 	).Once()
 
@@ -350,7 +354,7 @@ func TestGetSgNbUEX2APIDReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 
 func TestGetPsCellSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+	m.On("Get", someNs, []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
 		map[string]interface{}{someDbKeyPsCellPci: "10", someDbKeyPsCellSsbFreq: "20"}, nil,
 	).Once()
 
@@ -362,10 +366,10 @@ func TestGetPsCellSuccess(t *testing.T) {
 
 func TestGetPsCellWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+	m.On("Get", someNs, []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
 		map[string]interface{}{someDbKeyPsCellPci: "10", someDbKeyPsCellSsbFreq: "20"}, nil,
 	).Once()
 
@@ -404,7 +408,7 @@ func TestGetPsCellReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetPsCellReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(nil, dbError).Once()
 
 	ret, err := i.GetPsCell(&someUeID)
 
@@ -415,7 +419,7 @@ func TestGetPsCellReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetPsCellWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetPsCell(&anotherUeID)
 
@@ -425,7 +429,7 @@ func TestGetPsCellWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T)
 
 func TestGetPsCellReturnsErrorIfPciDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+	m.On("Get", someNs, []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
 		map[string]interface{}{someDbKeyPsCellPci: nil, someDbKeyPsCellSsbFreq: "20"}, nil,
 	).Once()
 
@@ -437,7 +441,7 @@ func TestGetPsCellReturnsErrorIfPciDbKeyValueNotFound(t *testing.T) {
 
 func TestGetPsCellReturnsErrorIfSsbFreqDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
+	m.On("Get", someNs, []string{someDbKeyPsCellPci, someDbKeyPsCellSsbFreq}).Return(
 		map[string]interface{}{someDbKeyPsCellPci: "10", someDbKeyPsCellSsbFreq: nil}, nil,
 	).Once()
 
@@ -449,7 +453,7 @@ func TestGetPsCellReturnsErrorIfSsbFreqDbKeyValueNotFound(t *testing.T) {
 
 func TestGetStateSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+	m.On("Get", someNs, []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
 		map[string]interface{}{
 			someDbKeyUeStateEvent: "2020-04-30T09:02:39.364571+03:00;SGNB-RECONF-CMPLT",
 			someDbKeyUeStateCause: nil,
@@ -464,7 +468,7 @@ func TestGetStateSuccess(t *testing.T) {
 
 func TestGetStateWithCauseSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+	m.On("Get", someNs, []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
 		map[string]interface{}{
 			someDbKeyUeStateEvent: "2020-04-30T09:02:39.364571+03:00;SGNB-ADD-REQ-REJ",
 			someDbKeyUeStateCause: "SGNB-ADD-REQ-REJ;radioNetwork;no_radio_resources_available",
@@ -482,10 +486,10 @@ func TestGetStateWithCauseSuccess(t *testing.T) {
 
 func TestGeStateWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+	m.On("Get", someNs, []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
 		map[string]interface{}{
 			someDbKeyUeStateEvent: "STATE-123",
 			someDbKeyUeStateCause: nil,
@@ -527,7 +531,7 @@ func TestGetStateReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetStateReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(nil, dbError).Once()
 
 	ret, err := i.GetState(&someUeID)
 
@@ -538,7 +542,7 @@ func TestGetStateReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetStateWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetState(&anotherUeID)
 
@@ -548,7 +552,7 @@ func TestGetStateWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) 
 
 func TestGetStateReturnsErrorIfEventDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
+	m.On("Get", someNs, []string{someDbKeyUeStateEvent, someDbKeyUeStateCause}).Return(
 		map[string]interface{}{
 			someDbKeyUeStateEvent: nil,
 			someDbKeyUeStateCause: "something",
@@ -563,7 +567,7 @@ func TestGetStateReturnsErrorIfEventDbKeyValueNotFound(t *testing.T) {
 
 func TestGetBearerIDsSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "1000,2000"}, nil,
 	).Once()
 
@@ -575,10 +579,10 @@ func TestGetBearerIDsSuccess(t *testing.T) {
 
 func TestGetBearerIDsWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "1000,2000"}, nil,
 	).Once()
 
@@ -617,7 +621,7 @@ func TestGetBearerIDsReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetBearerIDsReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(nil, dbError).Once()
 
 	ret, err := i.GetBearerIDs(&someUeID)
 
@@ -628,7 +632,7 @@ func TestGetBearerIDsReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetBearerIDsWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetBearerIDs(&anotherUeID)
 
@@ -638,7 +642,7 @@ func TestGetBearerIDsWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing
 
 func TestGetBearerIDsReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: nil}, nil,
 	).Once()
 
@@ -650,7 +654,7 @@ func TestGetBearerIDsReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 
 func TestGetBearerIDsReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "IamNotInt"}, nil,
 	).Once()
 
@@ -662,10 +666,10 @@ func TestGetBearerIDsReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 
 func TestGetBearersSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "1000,2000"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerDrbID,
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
@@ -726,10 +730,10 @@ func TestGetBearersReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
 
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "1000"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerDrbID,
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
@@ -746,7 +750,7 @@ func TestGetBearersReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetBearersReturnsErrorIfBearerIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(nil, dbError).Once()
 
 	ret, err := i.GetBearers(&someUeID)
 
@@ -757,7 +761,7 @@ func TestGetBearersReturnsErrorIfBearerIDDbQueryFails(t *testing.T) {
 func TestGetBearersWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetBearers(&anotherUeID)
 
@@ -767,10 +771,10 @@ func TestGetBearersWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T
 
 func TestGetBearersReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "1000"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerDrbID,
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
@@ -789,7 +793,7 @@ func TestGetBearersReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 
 func TestGetBearersReturnsErrorIfBearerIDDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: nil}, nil,
 	).Once()
 
@@ -801,10 +805,10 @@ func TestGetBearersReturnsErrorIfBearerIDDbKeyValueNotFound(t *testing.T) {
 
 func TestGetBearersReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyBearerIDs}).Return(
+	m.On("Get", someNs, []string{someDbKeyBearerIDs}).Return(
 		map[string]interface{}{someDbKeyBearerIDs: "1000"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerDrbID,
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
@@ -823,7 +827,7 @@ func TestGetBearersReturnsErrorIfValueConvertToUint32Fails(t *testing.T) {
 
 func TestGetErabS1ULGtpTESuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
@@ -840,10 +844,10 @@ func TestGetErabS1ULGtpTESuccess(t *testing.T) {
 
 func TestGetErabS1ULGtpTEWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
@@ -889,7 +893,7 @@ func TestGetErabS1ULGtpTEReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetErabS1ULGtpTEReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(nil, dbError).Once()
@@ -903,7 +907,7 @@ func TestGetErabS1ULGtpTEReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetErabS1ULGtpTEWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetErabS1ULGtpTE(&anotherUeID, someErabID)
 
@@ -913,7 +917,7 @@ func TestGetErabS1ULGtpTEWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *tes
 
 func TestGetErabS1ULGtpTEReturnsErrorIfAddressDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
@@ -930,7 +934,7 @@ func TestGetErabS1ULGtpTEReturnsErrorIfAddressDbKeyValueNotFound(t *testing.T) {
 
 func TestGetErabS1ULGtpTEReturnsErrorIfTeidDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
@@ -947,7 +951,7 @@ func TestGetErabS1ULGtpTEReturnsErrorIfTeidDbKeyValueNotFound(t *testing.T) {
 
 func TestGetErabS1ULGtpTEAddrSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 	}).Return(
 		map[string]interface{}{
@@ -962,10 +966,10 @@ func TestGetErabS1ULGtpTEAddrSuccess(t *testing.T) {
 
 func TestGetErabS1ULGtpTEAddrWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 	}).Return(
 		map[string]interface{}{
@@ -1009,7 +1013,7 @@ func TestGetErabS1ULGtpTEAddrReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetErabS1ULGtpTEAddrReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 	}).Return(nil, dbError).Once()
 
@@ -1022,7 +1026,7 @@ func TestGetErabS1ULGtpTEAddrReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetErabS1ULGtpTEAddrWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetErabS1ULGtpTEAddr(&anotherUeID, someErabID)
 
@@ -1032,7 +1036,7 @@ func TestGetErabS1ULGtpTEAddrWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t 
 
 func TestGetErabS1ULGtpTEAddrReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepAddr,
 	}).Return(
 		map[string]interface{}{
@@ -1047,7 +1051,7 @@ func TestGetErabS1ULGtpTEAddrReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 
 func TestGetErabS1ULGtpTETeidSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
 		map[string]interface{}{
@@ -1062,10 +1066,10 @@ func TestGetErabS1ULGtpTETeidSuccess(t *testing.T) {
 
 func TestGetErabS1ULGtpTETeidWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
 		map[string]interface{}{
@@ -1109,7 +1113,7 @@ func TestGetErabS1ULGtpTETeidReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetErabS1ULGtpTETeidReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(nil, dbError).Once()
 
@@ -1122,7 +1126,7 @@ func TestGetErabS1ULGtpTETeidReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetErabS1ULGtpTETeidWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetErabS1ULGtpTETeid(&anotherUeID, someErabID)
 
@@ -1132,7 +1136,7 @@ func TestGetErabS1ULGtpTETeidWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t 
 
 func TestGetErabS1ULGtpTETeidReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerS1ULTepTeid,
 	}).Return(
 		map[string]interface{}{
@@ -1147,7 +1151,7 @@ func TestGetErabS1ULGtpTETeidReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 
 func TestGetErabQosArpPLSuccessSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerArpPL,
 	}).Return(
 		map[string]interface{}{
@@ -1162,10 +1166,10 @@ func TestGetErabQosArpPLSuccessSuccess(t *testing.T) {
 
 func TestGetErabQosArpPLWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerArpPL,
 	}).Return(
 		map[string]interface{}{
@@ -1209,7 +1213,7 @@ func TestGetErabQosArpPLReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetErabQosArpPLReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerArpPL,
 	}).Return(nil, dbError).Once()
 
@@ -1222,7 +1226,7 @@ func TestGetErabQosArpPLReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetErabQosArpPLWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetErabQosArpPL(&anotherUeID, someErabID)
 
@@ -1232,7 +1236,7 @@ func TestGetErabQosArpPLWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *test
 
 func TestGetErabQosArpPLReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerArpPL,
 	}).Return(
 		map[string]interface{}{
@@ -1247,7 +1251,7 @@ func TestGetErabQosArpPLReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 
 func TestGetErabQosQciSuccessSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerQci,
 	}).Return(
 		map[string]interface{}{
@@ -1262,10 +1266,10 @@ func TestGetErabQosQciSuccessSuccess(t *testing.T) {
 
 func TestGetErabQosQciWithGnbX2ApIDSuccess(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(
 		map[string]interface{}{someDbKeyENbUeX2ApID: "100"}, nil,
 	).Once()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerQci,
 	}).Return(
 		map[string]interface{}{
@@ -1309,7 +1313,7 @@ func TestGetErabQosQciReturnsErrorIfNoUeX2ApID2UeID(t *testing.T) {
 func TestGetErabQosQciReturnsErrorIfDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerQci,
 	}).Return(nil, dbError).Once()
 
@@ -1322,7 +1326,7 @@ func TestGetErabQosQciReturnsErrorIfDbQueryFails(t *testing.T) {
 func TestGetErabQosQciWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testing.T) {
 	m, i := setup()
 	dbError := errors.New("Some DB Error")
-	m.On("Get", []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
+	m.On("Get", someNs, []string{someDbKeyENbUeX2ApID}).Return(nil, dbError).Once()
 
 	ret, err := i.GetErabQosQci(&anotherUeID, someErabID)
 
@@ -1332,7 +1336,7 @@ func TestGetErabQosQciWithGnbX2ApIDReturnsErrorIfEnbX2ApIDDbQueryFails(t *testin
 
 func TestGetErabQosQciReturnsErrorIfDbKeyValueNotFound(t *testing.T) {
 	m, i := setup()
-	m.On("Get", []string{
+	m.On("Get", someNs, []string{
 		someDbKeyBearerQci,
 	}).Return(
 		map[string]interface{}{

--- a/pkg/uenibreader/reader.go
+++ b/pkg/uenibreader/reader.go
@@ -23,7 +23,7 @@ type Reader struct {
 func NewReader() *Reader {
 	reader := &Reader{}
 	if !disableSdlCreationInConstructor {
-		reader.setDbBackend(sdl.NewSdlInstance("uenib", sdl.NewDatabase()))
+		reader.setDbBackend(sdl.NewSyncStorage())
 	}
 	return reader
 }
@@ -50,8 +50,8 @@ var disableSdlCreationInConstructor bool
 
 //SDL database backend interface.
 type iDbBackend interface {
-	Get(keys []string) (map[string]interface{}, error)
-	SubscribeChannel(cb func(string, ...string), channels ...string) error
+	Get(ns string, keys []string) (map[string]interface{}, error)
+	SubscribeChannel(ns string, cb func(string, ...string), channels ...string) error
 	Close() error
 }
 

--- a/pkg/uenibreader/reader_test.go
+++ b/pkg/uenibreader/reader_test.go
@@ -19,16 +19,16 @@ type mockSdlBackend struct {
 	mock.Mock
 }
 
-func (m *mockSdlBackend) Get(keys []string) (map[string]interface{}, error) {
-	a := m.Called(keys)
+func (m *mockSdlBackend) Get(ns string, keys []string) (map[string]interface{}, error) {
+	a := m.Called(ns, keys)
 	if a.Get(0) == nil {
 		return nil, a.Error(1)
 	}
 	return a.Get(0).(map[string]interface{}), a.Error(1)
 }
 
-func (m *mockSdlBackend) SubscribeChannel(cb func(string, ...string), channels ...string) error {
-	a := m.Called(cb, channels)
+func (m *mockSdlBackend) SubscribeChannel(ns string, cb func(string, ...string), channels ...string) error {
+	a := m.Called(ns, cb, channels)
 	return a.Error(0)
 }
 


### PR DESCRIPTION
Take SDL Golang package version 0.7.0 into use what brings multi-namespace
support and SDL DB capacity scaling where DB operation are spread out to
many DB instances based on their namespace value. Change UE-NIB-LIBRARY
reader queries to use GNB-ID in namespace string so that SDL DB queries are
targeted to the DB instance where to UE-NIB writer has written the data.